### PR TITLE
Adição de botão para desativação de conta com modal de confirmação

### DIFF
--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import logotipo from '../../../public/logotipo-sem-borda.svg';
+import logotipo from '/logotipo-sem-borda.svg';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();

--- a/frontend/src/components/perfil/ConfirmDeactivateDialog.jsx
+++ b/frontend/src/components/perfil/ConfirmDeactivateDialog.jsx
@@ -1,0 +1,34 @@
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+
+export function ConfirmDeactivateDialog({ onConfirm }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Desativar Conta</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Tem certeza que deseja desativar sua conta?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Essa ação desativará seu acesso e suas denúncias deixarão de ser visíveis no sistema. Você pode reativar sua conta futuramente entrando em contato com o suporte.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Confirmar</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/hooks/useDeleteAccount.jsx
+++ b/frontend/src/hooks/useDeleteAccount.jsx
@@ -1,0 +1,32 @@
+import { useUpdateUserStatus } from "@/hooks/useUpdateUserStatus"
+import { getAuth, signOut } from "firebase/auth"
+import { useNavigate } from "react-router-dom"
+import { toast } from "sonner"
+import { auth } from "@/firebase/config"
+
+export function useDeleteAccount() {
+  const { updateStatusToInactive } = useUpdateUserStatus()
+  const navigate = useNavigate()
+
+
+  const deactivateAccount = async () => {
+    const user = auth.currentUser
+
+    if (!user) {
+      toast.error("Usuário não autenticado.")
+      return
+    }
+
+    try {
+      await updateStatusToInactive(user.uid)
+      await signOut(auth)
+      toast.success("Conta desativada com sucesso.")
+      navigate("/login")
+    } catch (error) {
+      console.error("Erro ao desativar conta:", error)
+      toast.error("Erro ao desativar conta.")
+    }
+  }
+
+  return { deactivateAccount }
+}

--- a/frontend/src/pages/PerfilUsuarioPage.jsx
+++ b/frontend/src/pages/PerfilUsuarioPage.jsx
@@ -9,6 +9,8 @@ import EditarPerfilForm from "@/components/perfil/EditarPerfilForm";
 import useUserProfile from "@/hooks/useUserProfile";
 import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useAuth } from "@/context/AuthContext";
+import { ConfirmDeactivateDialog } from "@/components/perfil/ConfirmDeactivateDialog";
+import { useDeleteAccount } from "@/hooks/useDeleteAccount"; // <--- certifique-se que está implementado
 
 const PerfilUsuarioPage = () => {
   const {
@@ -24,8 +26,10 @@ const PerfilUsuarioPage = () => {
     loading,
     isGoogleUser,
   } = useUserProfile();
+
   const { user } = useAuth();
   const userId = user?.uid;
+  const { deactivateAccount } = useDeleteAccount();
 
   if (loading || !usuarioData)
     return (
@@ -36,7 +40,7 @@ const PerfilUsuarioPage = () => {
       </div>
     );
 
-  const { reportCount,  } = usuarioData;
+  const { reportCount } = usuarioData;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -47,7 +51,7 @@ const PerfilUsuarioPage = () => {
         <div className="container mx-auto px-4 py-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {/* coluna de informações do usuário */}
-            <div className="md:col-span-1">
+            <div className="md:col-span-1 space-y-4">
               <PerfilUsuarioCard
                 usuario={usuarioData}
                 onEditClick={() => setIsEditDialogOpen(true)}
@@ -56,6 +60,9 @@ const PerfilUsuarioPage = () => {
                 totalDenuncias={reportCount}
                 porcentagemResolvidas={calcularPorcentagemResolvidas()}
               />
+              <div className="flex justify-center mt-4">
+                <ConfirmDeactivateDialog onConfirm={deactivateAccount} />
+              </div>
             </div>
 
             {/* coluna de conteúdo principal - "minhas denúncias" */}


### PR DESCRIPTION
### 🧾 Descrição
Esta PR adiciona a funcionalidade que permite ao usuário desativar sua conta diretamente pela página de perfil. Em vez de excluir definitivamente os dados, o status do usuário é atualizado para inactive no Firestore.

### ✅ Alterações principais

- [x] Utilização do hook useUpdateUserStatus para atualização do status do usuário.
- [x] Criação do hook useDeleteAccount para marcar o usuário como inativo.
- [x] Criação do componente ConfirmDeactivateDialog (componente Dialog do shadcn/ui) para confirmação da ação.
- [x] Inclusão do botão "Desativar conta" na página de perfil do usuário (PerfilUsuarioPage), centralizado sob as estatísticas.

### 🧪 Testes realizados

- [x]  Abertura e fechamento do modal de confirmação.
- [x]  Atualização de status no Firestore ao confirmar.
- [x]  Exibição de toast de sucesso ou erro.
- [x]  Redirecionamento do usuário após desativação da conta.

📷 Capturas de tela

![image](https://github.com/user-attachments/assets/8850b496-efd2-4b2a-87c9-776309b87e8f)


### 🚩 Como testar

1. Faça login com um usuário autenticado.
2. Acesse /perfil.
3. Clique no botão Desativar conta abaixo das estatísticas.
4. Confirme no modal.
5. Verifique no Firestore se o campo status foi alterado para inactive.

### 📌 Observações

> O status `inactive `pode ser usado futuramente para restaurar ou auditar contas desativadas.
Não apaga os dados do usuário (denúncias ou perfil), apenas impede login ou interação.