### PR TITLE
[13 pontos] Implementar confirmação visual ao excluir denúncia no perfil

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import AppRoutes from "./routes/AppRoutes";
 import { AuthProvider } from "./context/AuthContext";
+import { Toaster } from "./components/ui/toaster";
 
 
 function App() {
@@ -7,6 +8,7 @@ function App() {
   return (
     <AuthProvider>
       <AppRoutes />
+      <Toaster />
     </AuthProvider>
   );
 }

--- a/frontend/src/components/ui/confirm-delete-modal.jsx
+++ b/frontend/src/components/ui/confirm-delete-modal.jsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, Trash2 } from "lucide-react";
+
+const ConfirmDeleteModal = ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title = "Confirmar Exclusão",
+    description = "Esta ação não poderá ser desfeita. Deseja continuar?",
+    itemName = "denúncia",
+    isLoading = false }) => {
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="sm:max-w-[425px] rounded-lg border-gray-200">
+                <DialogHeader>
+                    <div className="flex items-center gap-3">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+                            <AlertTriangle className="h-6 w-6 text-red-600" />
+                        </div>
+                        <div>
+                            <DialogTitle className="text-lg font-semibold text-gray-900">
+                                {title}
+                            </DialogTitle>
+                            <DialogDescription className="text-sm text-gray-600">
+                                {description}
+                            </DialogDescription>
+                        </div>
+                    </div>
+                </DialogHeader>
+
+                <div className="py-5">
+                    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                        <div className="flex items-start gap-3">
+                            <Trash2 className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+                            <div>
+                                <h4 className="text-sm font-medium text-red-800">
+                                    Atenção: Ação irreversível
+                                </h4>
+                                <p className="text-sm text-red-700 mt-1 leanding-snug">
+                                    Ao confirmar, esta {itemName} será permanentemente removida do banco de dados do Cidade Integra e não poderá ser recuperada.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <DialogFooter className="gap-2">
+                    <Button
+                        variant="outline"
+                        onClick={onClose}
+                        disabled={isLoading}
+                        className="flex-1"
+                    >
+                        Cancelar
+                    </Button>
+
+                    <Button
+                        variant="destructive"
+                        onClick={onConfirm}
+                        disabled={isLoading}
+                        className="flex-1"
+                    >
+                        {isLoading ? (
+                            <div className="flex items-center gap-2">
+                                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                                Excluindo...
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-2">
+                                <Trash2 className="h-4 w-4" />
+                                Excluir
+                            </div>
+                        )}
+                    </Button>
+
+                </DialogFooter>
+
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+export default ConfirmDeleteModal;

--- a/frontend/src/hooks/useCurrentUser.jsx
+++ b/frontend/src/hooks/useCurrentUser.jsx
@@ -7,7 +7,8 @@ export function useCurrentUser() {
   const { user, loading, error } = useFetchUser(currentUser?.uid)
 
   return {
-    user,
+    currentUser,
+    currentUserData: user,
     loading,
     error,
   }


### PR DESCRIPTION
### 📌 [Perfil] Implementar confirmação visual ao excluir denúncia (13 pontos)

### 🧩 Descrição    
Ao excluir uma denúncia, o sistema atualmente executa a ação sem confirmar com o usuário. Esta melhoria adiciona um **modal de confirmação** e uma mensagem visual após a exclusão.

### 🎯 Objetivo  
- Prevenir exclusões acidentais.  
- Aplicar a heurística de **prevenção de erros e controle do usuário**. 
- Reforçar a confiança na interação.

### 📊 Pontuação: 13 pontos

### 🌱 Branch: `feature/confirma-exclusao-denuncia`

---------
### **Funções implementadas:** 
- Usuário comum consegue excluir sua própria denúncia
- Usuário administrador consegue excluir denúncia de outros usuários
-------
### **Prints de Evidências:**
**Usuário comum:** 
![image](https://github.com/user-attachments/assets/23e8cced-6391-4990-af8e-fde0e459b7d5)
![image](https://github.com/user-attachments/assets/dce64823-712e-4a10-9c6b-84b7585cb27a)
![image](https://github.com/user-attachments/assets/8b5fbd97-4d6b-4faf-8ebe-e815b34c4e9f)

**Administrador:** 
![image](https://github.com/user-attachments/assets/c417b276-1975-4a3f-b327-294e6b707e4d)
![image](https://github.com/user-attachments/assets/4048596e-01c5-443e-89f1-2f4b4a53e593)
![image](https://github.com/user-attachments/assets/0c685159-cac6-4ca2-ac38-3eb18eecb0c3)


