### PR TITLE
Adicionar “scrollspy” para realçar a seção atual no menu da página “Dúvidas”

### DIFF
--- a/frontend/src/components/faq/ContactSection.jsx
+++ b/frontend/src/components/faq/ContactSection.jsx
@@ -4,18 +4,21 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardTitle
+  CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Mail, Phone, ExternalLink } from "lucide-react";
+import { Mail, Phone } from "lucide-react";
 import { motion } from "framer-motion";
 
 const ContactSection = () => {
   return (
-    <Card className="border-none shadow-lg overflow-hidden">
+    <section id="contato" className="scroll-mt-24">
+      <Card className="border-none shadow-lg overflow-hidden">
         <CardHeader className="bg-gradient-to-r from-verde/10 to-verde/5 border-b border-gray-100 dark:border-gray-700">
           <CardTitle className="text-xl md:text-2xl text-azul flex items-center gap-2">
-            <span className="inline-flex items-center justify-center w-8 h-8 bg-verde text-white rounded-full">?</span>
+            <span className="inline-flex items-center justify-center w-8 h-8 bg-verde text-white rounded-full">
+              ?
+            </span>
             Ainda tem dúvidas?
           </CardTitle>
           <CardDescription className="text-base">
@@ -24,11 +27,11 @@ const ContactSection = () => {
         </CardHeader>
         <CardContent className="pt-6">
           <p className="text-muted-foreground mb-6 text-base">
-            Se você não encontrou a resposta para sua dúvida, entre em contato conosco
-            por um dos canais abaixo:
+            Se você não encontrou a resposta para sua dúvida, entre em contato
+            conosco por um dos canais abaixo:
           </p>
           <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-            <motion.div 
+            <motion.div
               className="bg-muted/50 p-4 sm:p-5 rounded-lg border border-gray-100 dark:border-gray-700 flex flex-col sm:flex-row items-start gap-3"
               whileHover={{ y: -3, transition: { duration: 0.2 } }}
             >
@@ -37,15 +40,21 @@ const ContactSection = () => {
               </span>
               <div className="w-full">
                 <h3 className="font-medium text-lg mb-2 text-azul">Email</h3>
-                <p className="text-sm text-muted-foreground mb-3 break-words">suporte@cidadeintegra.com</p>
-                <Button variant="outline" size="sm" className="text-verde border-verde hover:bg-verde hover:text-white w-full sm:w-auto">
+                <p className="text-sm text-muted-foreground mb-3 break-words">
+                  suporte@cidadeintegra.com
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-verde border-verde hover:bg-verde hover:text-white w-full sm:w-auto"
+                >
                   <Mail className="h-4 w-4 mr-2" />
-                  <a mailto="suporte@cidadeintegra"></a>Enviar email
+                  Enviar email
                 </Button>
               </div>
             </motion.div>
-            
-            <motion.div 
+
+            <motion.div
               className="bg-muted/50 p-4 sm:p-5 rounded-lg border border-gray-100 dark:border-gray-700 flex flex-col sm:flex-row items-start gap-3"
               whileHover={{ y: -3, transition: { duration: 0.2 } }}
             >
@@ -54,23 +63,23 @@ const ContactSection = () => {
               </span>
               <div className="w-full">
                 <h3 className="font-medium text-lg mb-2 text-azul">Telefone</h3>
-                <p className="text-sm text-muted-foreground mb-3">(99) 9999-9999</p>
-                <Button variant="outline" size="sm" className="text-verde border-verde hover:bg-verde hover:text-white w-full sm:w-auto">
+                <p className="text-sm text-muted-foreground mb-3">
+                  (99) 9999-9999
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-verde border-verde hover:bg-verde hover:text-white w-full sm:w-auto"
+                >
                   <Phone className="h-4 w-4 mr-2" />
                   Ligar agora
                 </Button>
               </div>
             </motion.div>
           </div>
-          
-          {/* <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700 text-center">
-            <Button variant="link" className="text-azul hover:text-verde">
-              <ExternalLink className="h-4 w-4 mr-2" />
-              Visite nossa Central de Ajuda
-            </Button>
-          </div> */}
         </CardContent>
       </Card>
+    </section>
   );
 };
 

--- a/frontend/src/components/faq/FAQCategory.jsx
+++ b/frontend/src/components/faq/FAQCategory.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { 
+import {
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -7,18 +7,31 @@ import {
 } from "@/components/ui/accordion";
 import { motion } from "framer-motion";
 
-const FAQCategory = ({ faqItems }) => {
+const FAQCategory = ({ id, title, faqItems }) => {
   return (
-    <div className="w-full">
+    <section id={id} className="scroll-mt-24 mb-12">
+      <motion.h2
+        className="text-2xl font-bold text-azul mb-4"
+        initial={{ opacity: 0, y: 10 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        {title}
+      </motion.h2>
+
       <Accordion type="single" collapsible className="w-full">
         {faqItems.map((item, index) => (
           <motion.div
             key={item.id}
             initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
             transition={{ duration: 0.3, delay: index * 0.1 }}
           >
-            <AccordionItem value={item.id} className="border-b border-gray-100 dark:border-gray-700 py-2">
+            <AccordionItem
+              value={item.id}
+              className="border-b border-gray-100 dark:border-gray-700 py-2"
+            >
               <AccordionTrigger className="text-lg font-medium text-azul hover:text-verde transition-colors duration-200 py-3">
                 {item.question}
               </AccordionTrigger>
@@ -29,7 +42,7 @@ const FAQCategory = ({ faqItems }) => {
           </motion.div>
         ))}
       </Accordion>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/faq/FAQHeader.jsx
+++ b/frontend/src/components/faq/FAQHeader.jsx
@@ -3,7 +3,7 @@ import { BookOpen } from "lucide-react";
 
 const FAQHeader = () => {
   return (
-    <div className="bg-azul text-white py-12">
+    <header className="bg-azul text-white py-12">
       <div className="container mx-auto px-4">
         <h1 className="text-3xl font-bold mb-4 flex items-center gap-2">
           <BookOpen className="h-7 w-7" />
@@ -13,7 +13,7 @@ const FAQHeader = () => {
           Encontre respostas para as dúvidas mais comuns sobre a plataforma.
         </p>
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/frontend/src/components/faq/FAQPage.jsx
+++ b/frontend/src/components/faq/FAQPage.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import FAQHeader from "./FAQHeader";
+import FAQSection from "./FAQSection";
+import ContactSection from "./ContactSection";
+
+const FAQPage = () => {
+  return (
+    <div className="scroll-smooth">
+      {/* Cabeçalho da página */}
+      <FAQHeader />
+
+      {/* Conteúdo principal: perguntas + contato */}
+      <main className="container mx-auto px-4 py-12 space-y-16">
+        <FAQSection />
+        <ContactSection />
+      </main>
+    </div>
+  );
+};
+
+export default FAQPage;

--- a/frontend/src/components/faq/FAQSection.jsx
+++ b/frontend/src/components/faq/FAQSection.jsx
@@ -1,57 +1,103 @@
-import React from "react";
-import { 
-  Card, 
-  CardContent, 
-  CardDescription, 
-  CardHeader, 
-  CardTitle 
+import React, { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import FAQCategory from "./FAQCategory";
 import { faqCategories } from "@/data/faqData";
-import { Separator } from "@/components/ui/separator";
 import { motion } from "framer-motion";
 
 const FAQSection = () => {
+  const [activeId, setActiveId] = useState(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    faqCategories.forEach((category) => {
+      const el = document.getElementById(category.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5, delay: 0.2 }}
+      className="flex flex-col md:flex-row gap-8"
     >
-      <Card className="mb-8 border-none shadow-lg">
-        <CardHeader className="bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 rounded-t-lg border-b border-gray-100 dark:border-gray-700">
-          <CardTitle className="text-xl md:text-2xl text-azul">Dúvidas sobre o Cidade Integra</CardTitle>
-          <CardDescription className="text-base">
-            Encontre respostas para suas perguntas nas seções abaixo.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="pt-6">
-          <div className="space-y-10">
+      {/* ScrollSpy Menu */}
+      <aside className="md:w-1/4 sticky top-4 h-fit">
+        <nav>
+          <ul className="space-y-2">
+            {faqCategories.map((category) => (
+              <li key={category.id} className="relative pl-4">
+                {activeId === category.id && (
+                  <span className="absolute left-0 top-2 h-6 w-1 rounded-full bg-primary" />
+                )}
+                <a
+                  href={`#${category.id}`}
+                  className={`block px-4 py-2 rounded-lg font-medium transition-colors duration-200 ${
+                    activeId === category.id
+                      ? "bg-muted text-primary"
+                      : "text-muted-foreground hover:text-primary hover:bg-muted/50"
+                  }`}
+                >
+                  {category.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+
+      {/* FAQ Content */}
+      <div className="md:w-3/4 space-y-10">
+        <Card className="border-none shadow-lg">
+          <CardHeader className="bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 rounded-t-lg border-b border-gray-100 dark:border-gray-700">
+            <CardTitle className="text-xl md:text-2xl text-azul">
+              Dúvidas sobre o Cidade Integra
+            </CardTitle>
+            <CardDescription className="text-base">
+              Encontre respostas para suas perguntas nas seções abaixo.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6">
             {faqCategories.map((category, index) => (
-              <motion.div 
+              <motion.div
                 key={category.id}
+                id={category.id}
+                className="scroll-mt-24"
                 initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.1 }}
               >
-                <div className="mb-4">
-                  <h3 className="text-lg md:text-xl font-semibold text-azul">{category.label}</h3>
-                  <Separator className="mt-2 bg-gray-100 dark:bg-gray-700" />
-                </div>
-                <div className="pl-1">
-                  <FAQCategory 
-                    categoryId={category.id} 
-                    faqItems={category.items}
-                  />
-                </div>
-                {index < faqCategories.length - 1 && (
-                  <div className="pt-6"></div>
-                )}
+                {/* Removido título duplicado aqui */}
+                <FAQCategory
+                  id={category.id}
+                  title={category.label}
+                  faqItems={category.items}
+                />
               </motion.div>
             ))}
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
     </motion.div>
   );
 };

--- a/frontend/src/data/faqData.jsx
+++ b/frontend/src/data/faqData.jsx
@@ -1,4 +1,3 @@
-
 export const faqCategories = [
   {
     id: "platform",
@@ -7,19 +6,22 @@ export const faqCategories = [
       {
         id: "item-1",
         question: "O que é o Cidade Integra?",
-        answer: "O Cidade Integra é uma plataforma que permite aos cidadãos reportar problemas ambientais e urbanos em sua cidade. Nossa missão é conectar a comunidade aos órgãos responsáveis para solucionar questões como poluição, descarte irregular de lixo, problemas de infraestrutura urbana e outros desafios ambientais."
+        answer:
+          "O Cidade Integra é uma plataforma que permite aos cidadãos reportar problemas ambientais e urbanos em sua cidade. Nossa missão é conectar a comunidade aos órgãos responsáveis para solucionar questões como poluição, descarte irregular de lixo, problemas de infraestrutura urbana e outros desafios ambientais.",
       },
       {
         id: "item-2",
         question: "Como a plataforma funciona?",
-        answer: "O funcionamento é simples: você registra o problema encontrado através do aplicativo, adicionando fotos, descrição e localização precisa. Nossa equipe analisa e encaminha a denúncia para o órgão responsável. Você pode acompanhar todo o processo de solução e será notificado quando o problema for resolvido."
+        answer:
+          "O funcionamento é simples: você registra o problema encontrado através do aplicativo, adicionando fotos, descrição e localização precisa. Nossa equipe analisa e encaminha a denúncia para o órgão responsável. Você pode acompanhar todo o processo de solução e será notificado quando o problema for resolvido.",
       },
       {
         id: "item-3",
         question: "É necessário pagar para usar o Cidade Integra?",
-        answer: "Não! O Cidade Integra é uma plataforma totalmente gratuita para todos os cidadãos. Nosso objetivo é facilitar a comunicação entre a população e os órgãos públicos responsáveis por solucionar os problemas reportados."
-      }
-    ]
+        answer:
+          "Não! O Cidade Integra é uma plataforma totalmente gratuita para todos os cidadãos. Nosso objetivo é facilitar a comunicação entre a população e os órgãos públicos responsáveis por solucionar os problemas reportados.",
+      },
+    ],
   },
   {
     id: "reports",
@@ -28,19 +30,22 @@ export const faqCategories = [
       {
         id: "item-1",
         question: "Como faço uma denúncia?",
-        answer: "Para fazer uma denúncia, clique no botão \"Nova Denúncia\" disponível no menu superior. Preencha o formulário com os detalhes do problema, adicione fotos que mostrem claramente a situação e marque a localização exata. Quanto mais informações você fornecer, mais rapidamente o problema poderá ser resolvido."
+        answer:
+          'Para fazer uma denúncia, clique no botão "Nova Denúncia" disponível no menu superior. Preencha o formulário com os detalhes do problema, adicione fotos que mostrem claramente a situação e marque a localização exata. Quanto mais informações você fornecer, mais rapidamente o problema poderá ser resolvido.',
       },
       {
         id: "item-2",
         question: "Posso fazer denúncias anônimas?",
-        answer: "Sim, você pode optar por fazer denúncias anônimas. Durante o preenchimento do formulário de denúncia, há uma opção para manter sua identidade privada. Mesmo em denúncias anônimas, você poderá acompanhar o progresso de solução através de um código único fornecido ao final do envio."
+        answer:
+          "Sim, você pode optar por fazer denúncias anônimas. Durante o preenchimento do formulário de denúncia, há uma opção para manter sua identidade privada. Mesmo em denúncias anônimas, você poderá acompanhar o progresso de solução através de um código único fornecido ao final do envio.",
       },
       {
         id: "item-3",
         question: "Como acompanho o status da minha denúncia?",
-        answer: "Você pode acompanhar suas denúncias através da seção \"Minhas Denúncias\" no seu perfil. Lá você encontrará todas as suas denúncias e seus respectivos status atuais. Também enviamos notificações por email quando houver atualizações importantes sobre o andamento da solução."
-      }
-    ]
+        answer:
+          'Você pode acompanhar suas denúncias através da seção "Minhas Denúncias" no seu perfil. Lá você encontrará todas as suas denúncias e seus respectivos status atuais. Também enviamos notificações por email quando houver atualizações importantes sobre o andamento da solução.',
+      },
+    ],
   },
   {
     id: "account",
@@ -49,18 +54,21 @@ export const faqCategories = [
       {
         id: "item-1",
         question: "Como criar uma conta no Cidade Integra?",
-        answer: "Para criar uma conta, clique em \"Entrar\" no menu superior e depois selecione a opção \"Cadastrar\". Você precisará fornecer seu nome, email e criar uma senha. Também é possível se cadastrar utilizando sua conta do Google ou Facebook para maior praticidade."
+        answer:
+          'Para criar uma conta, clique em "Entrar" no menu superior e depois selecione a opção "Cadastrar". Você precisará fornecer seu nome, email e criar uma senha. Também é possível se cadastrar utilizando sua conta do Google ou Facebook para maior praticidade.',
       },
       {
         id: "item-2",
         question: "Como editar meus dados pessoais?",
-        answer: "Para editar seus dados pessoais, acesse a página de \"Perfil\" e clique no botão \"Editar Perfil\". Lá você poderá atualizar seu nome, email, telefone e senha. Após fazer as alterações desejadas, clique em \"Salvar\" para confirmar as mudanças."
+        answer:
+          'Para editar seus dados pessoais, acesse a página de "Perfil" e clique no botão "Editar Perfil". Lá você poderá atualizar seu nome, email, telefone e senha. Após fazer as alterações desejadas, clique em "Salvar" para confirmar as mudanças.',
       },
       {
         id: "item-3",
         question: "Esqueci minha senha. Como recuperá-la?",
-        answer: "Se você esqueceu sua senha, clique em \"Entrar\" e depois na opção \"Esqueceu sua senha?\". Você será redirecionado para a página de recuperação, onde deverá informar o email cadastrado. Enviaremos um link para você criar uma nova senha de acesso."
-      }
-    ]
-  }
+        answer:
+          'Se você esqueceu sua senha, clique em "Entrar" e depois na opção "Esqueceu sua senha?". Você será redirecionado para a página de recuperação, onde deverá informar o email cadastrado. Enviaremos um link para você criar uma nova senha de acesso.',
+      },
+    ],
+  },
 ];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,6 +58,7 @@
   }
 }
 
+
 @layer base {
   * {
     @apply border-border;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cidade-unida-frontend",
+  "name": "cidade-integra-frontend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
### 📌 [Dúvidas] Adicionar “scrollspy” para realçar seção visível (13 pontos)

### 🧩 Descrição  
Na página “Dúvidas”, ao rolar o conteúdo, não há destaque visual para a seção em exibição. Esta melhoria implementa um sistema de **scrollspy** para indicar qual pergunta está ativa no menu lateral ou cabeçalho.

### 🎯 Objetivo  
- Melhorar a orientação do usuário na navegação por conteúdo longo.  
- Aplicar a heurística de **visibilidade do status do sistema**.  
- Tornar a interface mais fluida e interativa.

### 📊 Pontuação: 13 pontos

### 🌱 Branch: `feature/scrollspy-duvidas`

![Captura de tela 2025-06-21 111606](https://github.com/user-attachments/assets/3d8ab42d-cddb-4ece-ab98-0e0a311c317b)

