### PR TITLE
[3 pontos] Ajustar contraste dos botões principais para acessibilidade

### DIFF
--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,8 +1,10 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
+// Arquivo: src/components/ui/button.jsx - VERSÃO CORRIGIDA PARA ACESSIBILIDADE
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -18,7 +20,8 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+
+        link: "text-blue-700 dark:text-blue-300 underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
@@ -32,17 +35,20 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
-const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
-  const Comp = asChild ? Slot : "button"
-  return (
-    <Comp
-      className={cn(buttonVariants({ variant, size, className }))}
-      ref={ref}
-      {...props} />
-  );
-})
-Button.displayName = "Button"
+const Button = React.forwardRef(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,18 +18,22 @@
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
     --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
+
+    --destructive: 0 84% 37%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
+
+    --border: 0 0% 22%;
+    --input: 0 0% 22%;
+
     --ring: 0 0% 3.9%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem
+    --radius: 0.5rem;
   }
+
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -47,14 +51,16 @@
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+
+    --border: 0 0% 83%;
+    --input: 0 0% 83%;
+
     --ring: 0 0% 83.1%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-5: 340 75% 55%;
   }
 }
 


### PR DESCRIPTION
### 📌 [Acessibilidade] Ajustar contraste dos botões principais (3 pontos)

### 🧩 Descrição
Durante a Avaliação Técnica 2, foi identificado que os botões principais do sistema apresentam **baixo contraste**, o que compromete a **acessibilidade visual** para usuários com dificuldades de percepção de cor ou baixa visão.

Essa melhoria visa **adequar o contraste dos botões às boas práticas de acessibilidade**, alinhando-se às recomendações da WCAG (Web Content Accessibility Guidelines) e ao princípio heurístico de **visibilidade do sistema** e **design acessível**.

### 🎯 Objetivo
- Aumentar a legibilidade dos textos nos botões.
- Tornar os botões mais perceptíveis visualmente.
- Melhorar a pontuação de acessibilidade geral da aplicação.

### 📊 Pontuação: 3 pontos

### 🌱 Branch: `fix/button-contrast-accessibility`

![Captura de tela 2025-06-21 114949](https://github.com/user-attachments/assets/08942f5f-2ef0-49ba-abcf-9a09ed0b3984)
