### PR TITLE
[13 pontos] Implementar confirmação visual ao excluir denúncia no perfil

### DIFF
--- a/frontend/src/components/admin/denuncias/DenunciasTable.jsx
+++ b/frontend/src/components/admin/denuncias/DenunciasTable.jsx
@@ -1,15 +1,36 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Eye, CheckCircle, XCircle, Loader2 } from "lucide-react";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import DenunciaStatusBadge from "@/components/denuncias/DenunciaStatusBadge";
 import { useReport } from "@/hooks/useReport";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 
 const DenunciasTable = ({ denuncias, setDenuncias }) => {
-  const { markAsResolved, markAsRejected, markAsInReview, loading } = useReport();
+  const { markAsResolved, markAsRejected, markAsInReview, loading } =
+    useReport();
   const { toast } = useToast();
+
+  // Estado para controlar o modal
+  const [modalRejeitar, setModalRejeitar] = useState({
+    open: false,
+    reportId: null,
+  });
 
   // função para lidar com a atualização do status
   const handleUpdateStatus = async (id, status) => {
@@ -49,81 +70,145 @@ const DenunciasTable = ({ denuncias, setDenuncias }) => {
   };
 
   return (
-    <div className="rounded-md border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>ID</TableHead>
-            <TableHead>Título</TableHead>
-            <TableHead>Local</TableHead>
-            <TableHead>Data</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead className="text-right">Ações</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {denuncias.length === 0 ? (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
             <TableRow>
-              <TableCell colSpan={6} className="text-center py-10 text-muted-foreground">
-                Nenhuma denúncia encontrada.
-              </TableCell>
+              <TableHead>ID</TableHead>
+              <TableHead>Título</TableHead>
+              <TableHead>Local</TableHead>
+              <TableHead>Data</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Ações</TableHead>
             </TableRow>
-          ) : (
-            denuncias.map((denuncia) => (
-              <TableRow key={denuncia.reportId}> {/* Alterado para 'reportId' */}
-                <TableCell className="font-medium">{denuncia.reportId}</TableCell>
-                <TableCell>{denuncia.title}</TableCell>
-                <TableCell>{denuncia.location?.address}</TableCell>
-                <TableCell>{new Date(denuncia.createdAt?.seconds * 1000).toLocaleDateString('pt-BR')}</TableCell>
-                <TableCell>
-                  <DenunciaStatusBadge status={denuncia.status} />
-                </TableCell>
-                <TableCell className="text-right flex flex-col space-y-2">
-                  <Button variant="ghost" size="sm" asChild>
-                    <Link to={`/denuncias/${denuncia.reportId}`}>
-                      <Eye className="h-4 w-4 mr-1" />
-                      Ver
-                    </Link>
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "review")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <XCircle className="h-4 w-4 mr-1" />}
-                    Em Análise
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-verde hover:text-verde hover:bg-verde/10"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "resolved")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <CheckCircle className="h-4 w-4 mr-1" />}
-                    Resolver
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-vermelho hover:text-vermelho hover:bg-vermelho/10"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "rejected")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <XCircle className="h-4 w-4 mr-1" />}
-                    Rejeitar
-                  </Button>
+          </TableHeader>
+          <TableBody>
+            {denuncias.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center py-10 text-muted-foreground"
+                >
+                  Nenhuma denúncia encontrada.
                 </TableCell>
               </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
+            ) : (
+              denuncias.map((denuncia) => (
+                <TableRow key={denuncia.reportId}>
+                  {" "}
+                  {/* Alterado para 'reportId' */}
+                  <TableCell className="font-medium">
+                    {denuncia.reportId}
+                  </TableCell>
+                  <TableCell>{denuncia.title}</TableCell>
+                  <TableCell>{denuncia.location?.address}</TableCell>
+                  <TableCell>
+                    {new Date(
+                      denuncia.createdAt?.seconds * 1000
+                    ).toLocaleDateString("pt-BR")}
+                  </TableCell>
+                  <TableCell>
+                    <DenunciaStatusBadge status={denuncia.status} />
+                  </TableCell>
+                  <TableCell className="text-right flex flex-col space-y-2">
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link to={`/denuncias/${denuncia.reportId}`}>
+                        <Eye className="h-4 w-4 mr-1" />
+                        Ver
+                      </Link>
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
+                      onClick={() =>
+                        handleUpdateStatus(denuncia.reportId, "review")
+                      }
+                      disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <XCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Em Análise
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-verde hover:text-verde hover:bg-verde/10"
+                      onClick={() =>
+                        handleUpdateStatus(denuncia.reportId, "resolved")
+                      }
+                      disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <CheckCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Resolver
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-vermelho hover:text-vermelho hover:bg-vermelho/10"
+                      onClick={() =>
+                        setModalRejeitar({
+                          open: true,
+                          reportId: denuncia.reportId,
+                        })
+                      }
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <XCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Rejeitar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Modal de confirmação */}
+      <Dialog
+        open={modalRejeitar.open}
+        onOpenChange={(open) => setModalRejeitar((v) => ({ ...v, open }))}
+      >
+        <DialogContent>
+          <DialogTitle>Confirmar rejeição</DialogTitle>
+          <DialogDescription>
+            Tem certeza que deseja marcar esta denúncia como <b>rejeitada</b>?
+          </DialogDescription>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setModalRejeitar({ open: false, reportId: null })}
+            >
+              Cancelar
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={async () => {
+                await handleUpdateStatus(modalRejeitar.reportId, "rejected");
+                setModalRejeitar({ open: false, reportId: null });
+              }}
+              disabled={loading}
+            >
+              Confirmar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
### 📌 [Perfil] Implementar confirmação visual ao excluir denúncia (13 pontos)

### 🧩 Descrição  
Ao excluir uma denúncia, o sistema atualmente executa a ação sem confirmar com o usuário administador. Esta melhoria adiciona um **modal de confirmação** e uma mensagem visual após a exclusão.

### 🎯 Objetivo  
- Prevenir exclusões acidentais.  
- Aplicar a heurística de **prevenção de erros e controle do usuário**.  
- Reforçar a confiança na interação.

### 📊 Pontuação: 13 pontos

### 🌱 Branch: `feature/confirma-exclusao-denuncia`
------

### **Prinst de Evidência:**
![image](https://github.com/user-attachments/assets/a1d5087e-29a2-4d41-a907-fe6886139b22)
![image](https://github.com/user-attachments/assets/bb9a34ec-3703-4b79-ba81-5c9dff0d6e6a)
![image](https://github.com/user-attachments/assets/df20d03f-aed5-435e-9371-dbbc3ba4959c)

