### PR TITLE
Implementar logs de auditoria para ações administrativas

### DIFF
--- a/frontend/src/components/admin/denuncias/DenunciasTable.jsx
+++ b/frontend/src/components/admin/denuncias/DenunciasTable.jsx
@@ -1,14 +1,22 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Eye, CheckCircle, XCircle, Loader2 } from "lucide-react";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import DenunciaStatusBadge from "@/components/denuncias/DenunciaStatusBadge";
 import { useReport } from "@/hooks/useReport";
 
 const DenunciasTable = ({ denuncias, setDenuncias }) => {
-  const { markAsResolved, markAsRejected, markAsInReview, loading } = useReport();
+  const { markAsResolved, markAsRejected, markAsInReview, loading } =
+    useReport();
   const { toast } = useToast();
 
   // função para lidar com a atualização do status
@@ -62,66 +70,95 @@ const DenunciasTable = ({ denuncias, setDenuncias }) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {denuncias.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={6} className="text-center py-10 text-muted-foreground">
-                Nenhuma denúncia encontrada.
-              </TableCell>
-            </TableRow>
-          ) : (
-            denuncias.map((denuncia) => (
-              <TableRow key={denuncia.reportId}> {/* Alterado para 'reportId' */}
-                <TableCell className="font-medium">{denuncia.reportId}</TableCell>
-                <TableCell>{denuncia.title}</TableCell>
-                <TableCell>{denuncia.location?.address}</TableCell>
-                <TableCell>{new Date(denuncia.createdAt?.seconds * 1000).toLocaleDateString('pt-BR')}</TableCell>
-                <TableCell>
-                  <DenunciaStatusBadge status={denuncia.status} />
-                </TableCell>
-                <TableCell className="text-right flex flex-col space-y-2">
-                  <Button variant="ghost" size="sm" asChild>
-                    <Link to={`/denuncias/${denuncia.reportId}`}>
-                      <Eye className="h-4 w-4 mr-1" />
-                      Ver
-                    </Link>
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "review")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <XCircle className="h-4 w-4 mr-1" />}
-                    Em Análise
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-verde hover:text-verde hover:bg-verde/10"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "resolved")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <CheckCircle className="h-4 w-4 mr-1" />}
-                    Resolver
-                  </Button>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-vermelho hover:text-vermelho hover:bg-vermelho/10"
-                    onClick={() => handleUpdateStatus(denuncia.reportId, "rejected")}
-                    disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
-                  >
-                    {loading ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <XCircle className="h-4 w-4 mr-1" />}
-                    Rejeitar
-                  </Button>
+          <>
+            {denuncias.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center py-10 text-muted-foreground"
+                >
+                  Nenhuma denúncia encontrada.
                 </TableCell>
               </TableRow>
-            ))
-          )}
+            ) : (
+              denuncias.map((denuncia) => (
+                <TableRow key={denuncia.reportId}>
+                  <TableCell className="font-medium">
+                    {denuncia.reportId}
+                  </TableCell>
+                  <TableCell>{denuncia.title}</TableCell>
+                  <TableCell>{denuncia.location?.address}</TableCell>
+                  <TableCell>
+                    {new Date(
+                      denuncia.createdAt?.seconds * 1000
+                    ).toLocaleDateString("pt-BR")}
+                  </TableCell>
+                  <TableCell>
+                    <DenunciaStatusBadge status={denuncia.status} />
+                  </TableCell>
+                  <TableCell className="text-right flex flex-col space-y-2">
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link to={`/denuncias/${denuncia.reportId}`}>
+                        <Eye className="h-4 w-4 mr-1" />
+                        Ver
+                      </Link>
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
+                      onClick={() =>
+                        handleUpdateStatus(denuncia.reportId, "review")
+                      }
+                      disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <XCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Em Análise
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-verde hover:text-verde hover:bg-verde/10"
+                      onClick={() =>
+                        handleUpdateStatus(denuncia.reportId, "resolved")
+                      }
+                      disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <CheckCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Resolver
+                    </Button>
+
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-vermelho hover:text-vermelho hover:bg-vermelho/10"
+                      onClick={() =>
+                        handleUpdateStatus(denuncia.reportId, "rejected")
+                      }
+                      disabled={loading} // desabilita o botão enquanto o status está sendo atualizado
+                    >
+                      {loading ? (
+                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      ) : (
+                        <XCircle className="h-4 w-4 mr-1" />
+                      )}
+                      Rejeitar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </>
         </TableBody>
       </Table>
     </div>

--- a/frontend/src/hooks/useReport.jsx
+++ b/frontend/src/hooks/useReport.jsx
@@ -13,41 +13,44 @@ import {
   addDoc,
   increment,
   where,
-} from "firebase/firestore"
-import { db } from "../firebase/config"
-import { useState } from "react"
-import { useUploadImageReport } from "./useUploadImageReport"
+} from "firebase/firestore";
+import { db } from "../firebase/config";
+import { useState } from "react";
+import { useUploadImageReport } from "./useUploadImageReport";
+import { logAudit } from "@/utils/logAudit";
 
-const REPORT_COLLECTION = "reports"
+const REPORT_COLLECTION = "reports";
 
 export function useReport() {
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
-  const reportsRef = collection(db, REPORT_COLLECTION)
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const reportsRef = collection(db, REPORT_COLLECTION);
 
   // criar denúncia
   const createReport = async (report) => {
-    setLoading(true)
-    setError(null)
-  
+    setLoading(true);
+    setError(null);
+
     try {
-      const now = Timestamp.now()
-      let imagemUrlSupabase = null
-  
+      const now = Timestamp.now();
+      let imagemUrlSupabase = null;
+
       // se houver imagem, faz upload no Supabase
       if (report.imagemFile && report.userId) {
         const uploadResult = await useUploadImageReport(
           report.imagemFile,
           report.userId
-        )
-  
+        );
+
         if (!uploadResult.success) {
-          throw new Error(uploadResult.error || "Falha ao fazer upload da imagem.")
+          throw new Error(
+            uploadResult.error || "Falha ao fazer upload da imagem."
+          );
         }
-  
-        imagemUrlSupabase = uploadResult.url
+
+        imagemUrlSupabase = uploadResult.url;
       }
-  
+
       // monta o objeto da denúncia
       const reportData = {
         ...report,
@@ -56,76 +59,76 @@ export function useReport() {
         updatedAt: now,
         status: "pending",
         resolvedAt: null,
-      }
-  
-      delete reportData.imagemFile // remover o File do objeto antes de salvar no Firestore
-  
-      const docRef = await addDoc(reportsRef, reportData)
-  
+      };
+
+      delete reportData.imagemFile; // remover o File do objeto antes de salvar no Firestore
+
+      const docRef = await addDoc(reportsRef, reportData);
+
       // atualiza contador de denúncias do usuário, se aplicável
       if (report.userId) {
-        const userRef = doc(db, "users", report.userId)
+        const userRef = doc(db, "users", report.userId);
         await updateDoc(userRef, {
           reportCount: increment(1),
-        })
+        });
       }
-  
-      return docRef.id
+
+      return docRef.id;
     } catch (err) {
-      console.error("Erro ao criar denúncia:", err)
-      setError(err.message || "Erro desconhecido ao criar denúncia.")
-      throw err
+      console.error("Erro ao criar denúncia:", err);
+      setError(err.message || "Erro desconhecido ao criar denúncia.");
+      throw err;
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   // buscar denúncia por ID
   const getReportById = async (id) => {
-    setLoading(true)
-    setError(null)
+    setLoading(true);
+    setError(null);
 
     try {
-      const docSnap = await getDoc(doc(db, REPORT_COLLECTION, id))
+      const docSnap = await getDoc(doc(db, REPORT_COLLECTION, id));
       if (docSnap.exists()) {
-        return { reportId: docSnap.id, ...docSnap.data() }
+        return { reportId: docSnap.id, ...docSnap.data() };
       }
-      return null
+      return null;
     } catch (err) {
-      setError(err)
-      return null
+      setError(err);
+      return null;
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   // buscar todas as denúncias
   const getAllReports = async (userId) => {
-    setLoading(true)
-    setError(null)
+    setLoading(true);
+    setError(null);
 
     try {
-      let q = query(reportsRef, orderBy("createdAt", "desc"))
+      let q = query(reportsRef, orderBy("createdAt", "desc"));
       if (userId) {
         q = query(
           reportsRef,
           where("userId", "==", userId),
           orderBy("createdAt", "desc")
-        )
+        );
       }
 
-      const querySnapshot = await getDocs(q)
+      const querySnapshot = await getDocs(q);
       return querySnapshot.docs.map((doc) => ({
         reportId: doc.id,
         ...doc.data(),
-      }))
+      }));
     } catch (err) {
-      setError(err)
-      return []
+      setError(err);
+      return [];
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   // buscar as primeiras denúncias
   const getInitialReports = async (verifyLimitCount, limitCount) => {
@@ -134,122 +137,134 @@ export function useReport() {
         collection(db, REPORT_COLLECTION),
         orderBy("createdAt", "desc"),
         limit(verifyLimitCount)
-      )
-      const snapshotVerify = await getDocs(qVerify)
+      );
+      const snapshotVerify = await getDocs(qVerify);
 
       const verify = snapshotVerify.docs.map((doc) => ({
         reportId: doc.id,
         ...doc.data(),
-      }))
+      }));
 
       const qReports = query(
         collection(db, REPORT_COLLECTION),
         orderBy("createdAt", "desc"),
         limit(limitCount)
-      )
-      const snapshot = await getDocs(qReports)
+      );
+      const snapshot = await getDocs(qReports);
 
       const reports = snapshot.docs.map((doc) => ({
         reportId: doc.id,
         ...doc.data(),
-      }))
+      }));
 
-      const lastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null
+      const lastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null;
 
-      return {verify, reports, lastVisible }
+      return { verify, reports, lastVisible };
     } catch (err) {
-      throw err
+      throw err;
     }
-  }
+  };
 
   // buscar mais denúncias
   const getMoreReports = async (lastDoc, verifyLimitCount, limitCount) => {
     try {
-      const qMoreVerify = query (
+      const qMoreVerify = query(
         collection(db, REPORT_COLLECTION),
         orderBy("createdAt", "desc"),
         startAfter(lastDoc),
         limit(verifyLimitCount)
-      )
-      const snapshotVerify = await getDocs(qMoreVerify)
+      );
+      const snapshotVerify = await getDocs(qMoreVerify);
 
       const verify = snapshotVerify.docs.map((doc) => ({
         reportId: doc.id,
         ...doc.data(),
-      }))
+      }));
 
       const qMoreReports = query(
         collection(db, REPORT_COLLECTION),
         orderBy("createdAt", "desc"),
         startAfter(lastDoc),
         limit(limitCount)
-      )
-      const snapshot = await getDocs(qMoreReports)
+      );
+      const snapshot = await getDocs(qMoreReports);
 
       const reports = snapshot.docs.map((doc) => ({
         reportId: doc.id,
         ...doc.data(),
-      }))
+      }));
 
-      const newLastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null
+      const newLastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null;
 
-      return {verify, reports, lastVisible: newLastVisible }
+      return { verify, reports, lastVisible: newLastVisible };
     } catch (err) {
-      throw err
+      throw err;
     }
-  }
+  };
 
   // atualizar denúncia
   const updateReport = async (id, updates) => {
-    setLoading(true)
-    setError(null)
+    setLoading(true);
+    setError(null);
 
     try {
       await updateDoc(doc(db, REPORT_COLLECTION, id), {
         ...updates,
         updatedAt: Timestamp.now(),
-      })
-      return true
+      });
+      return true;
     } catch (err) {
-      setError(err)
-      return false
+      setError(err);
+      return false;
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   // deletar denúncia
   const deleteReport = async (id) => {
-    setLoading(true)
-    setError(null)
-
-    try {
-      await deleteDoc(doc(db, REPORT_COLLECTION, id))
-    } catch (err) {
-      setError(err)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  // atualizar o status da denúncia
-  const updateStatus = async (reportId, status) => {
     setLoading(true);
     setError(null);
 
     try {
+      await deleteDoc(doc(db, REPORT_COLLECTION, id));
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // atualizar o status da denúncia
+  const updateStatus = async (reportId, newStatus, comment = null) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const reportRef = doc(db, REPORT_COLLECTION, reportId);
+      const snapshot = await getDoc(reportRef);
+      const reportData = snapshot.data();
+
+      const oldStatus = reportData?.status || "unknown";
+
       const update = {
-        status,
+        status: newStatus,
         updatedAt: Timestamp.now(),
       };
 
-      // adicionar resolvedAt somente se a denúncia for marcada como "resolvida"
-      if (status === "resolved") {
+      if (newStatus === "resolved") {
         update.resolvedAt = Timestamp.now();
       }
 
-      // atualizando a denúncia no Firestore
-      await updateDoc(doc(db, REPORT_COLLECTION, reportId), update);
+      await updateDoc(reportRef, update);
+
+      await logAudit({
+        reportId,
+        action: "status_change",
+        oldStatus,
+        newStatus,
+        comment,
+      });
     } catch (err) {
       console.error("Erro ao atualizar o status:", err);
       setError("Ocorreu um erro ao atualizar o status da denúncia.");
@@ -259,10 +274,10 @@ export function useReport() {
   };
 
   // funções para atualizar o status de cada denúncia
-  const markAsResolved = (id) => updateStatus(id, "resolved");
-  const markAsInReview = (id) => updateStatus(id, "review");
-  const markAsRejected = (id) => updateStatus(id, "rejected");
-  
+  const markAsResolved = (id, comment) => updateStatus(id, "resolved", comment);
+  const markAsInReview = (id, comment) => updateStatus(id, "review", comment);
+  const markAsRejected = (id, comment) => updateStatus(id, "rejected", comment);
+
   return {
     loading,
     error,
@@ -276,5 +291,5 @@ export function useReport() {
     markAsRejected,
     getInitialReports,
     getMoreReports,
-  }
+  };
 }

--- a/frontend/src/utils/logAudit.jsx
+++ b/frontend/src/utils/logAudit.jsx
@@ -1,0 +1,28 @@
+import { addDoc, collection, serverTimesTamp } from "firebase/firestore";
+import { db } from "@/firebase/config";
+import { getAuth } from "firebase/auth";
+
+export async function logAudit({
+  reportId,
+  action,
+  oldStatus,
+  newStatus,
+  comment,
+}) {
+  const auth = getAuth();
+  const user = auth.currentUser;
+
+  if (!user) return;
+
+  await addDoc(collection(db, "auditlogs"), {
+    timestamp: serverTimestamp(),
+    userId: user.uid,
+    userDisplayName: user.displayName || "Desconhecido",
+    reportId,
+    action,
+    oldStatus,
+    newStatus,
+    comment: comment || null,
+    userAgent: navigator.userAgent,
+  });
+}


### PR DESCRIPTION
### 📌 [Auditoria] Implementar logs de auditoria para ações administrativas (34 pontos)

### 🧩 Descrição  
Criar uma **collection `audit_logs` no Firestore** para armazenar eventos administrativos, como exclusão, edição ou resposta a denúncias. Cada log deve conter data, ID do administrador e tipo de ação.

### 🎯 Objetivo  
- Aumentar a rastreabilidade de ações críticas.  
- Reforçar a segurança e responsabilidade administrativa.  
- Permitir revisões e investigações em caso de erro ou abuso.

### 📊 Pontuação: 34 pontos

### 🌱 Branch: `feature/admin-audit-logs`