### PR TITLE
[5 pontos] Tornar os ícones da página "Sobre" semanticamente relevantes

### DIFF
--- a/frontend/src/components/perfil/EstatisticasCard.jsx
+++ b/frontend/src/components/perfil/EstatisticasCard.jsx
@@ -21,14 +21,14 @@ const EstatisticasCard = ({ totalDenuncias, porcentagemResolvidas }) => {
                     <TooltipTrigger asChild>
                       <Info className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" aria-label="Clique para saber como funciona os critérios de pontuação"/>
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-xs">
+                    <TooltipContent side="top" className="max-w-xs bg-verde text-white">
                       <div className="space-y-2 text-sm">
-                        <p className="font-medium">Como funciona a pontuação:</p>
+                        <p className="font-medium">Como funciona a pontuação?</p>
                         <ul className="space-y-1 text-xs">
-                          <li>• +10 pontos por denúncia criada</li>
-                          <li>• +20 pontos por denúncia resolvida</li>
+                          <li>+10 pontos por denúncia criada</li>
+                          <li>+20 pontos por denúncia resolvida</li>
                         </ul>
-                        <p className="text-xs text-muted-foreground mt-2">
+                        <p className="text-xs text-muted-foreground mt-2 text-white">
                           Acumule pontos para subir de nível e ganhar distintivos especiais!
                         </p>
                       </div>

--- a/frontend/src/pages/PerfilUsuarioPage.jsx
+++ b/frontend/src/pages/PerfilUsuarioPage.jsx
@@ -10,7 +10,7 @@ import useUserProfile from "@/hooks/useUserProfile";
 import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useAuth } from "@/context/AuthContext";
 import { ConfirmDeactivateDialog } from "@/components/perfil/ConfirmDeactivateDialog";
-import { useDeleteAccount } from "@/hooks/useDeleteAccount"; // <--- certifique-se que está implementado
+import { useDeleteAccount } from "@/hooks/useDeleteAccount";
 
 const PerfilUsuarioPage = () => {
   const {

--- a/frontend/src/pages/SobrePage.jsx
+++ b/frontend/src/pages/SobrePage.jsx
@@ -3,7 +3,7 @@ import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import { students } from "@/data/equipe";
 import { motion } from "framer-motion";
-import { MapPin } from "lucide-react";
+import { Link, HeartHandshake, Zap } from "lucide-react";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 
@@ -94,7 +94,7 @@ const SobrePage = () => {
                   className="bg-azul/40 p-6 rounded-lg backdrop-blur-sm"
                 >
                   <div className="bg-verde/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <MapPin className="h-7 w-7 text-verde" />
+                    <Link className="h-7 w-7 text-verde" />
                   </div>
                   <h3 className="text-xl font-semibold mb-2 text-verde">Conectar</h3>
                   <p className="text-cinza">Criar uma ponte eficiente entre cidadãos e órgãos responsáveis.</p>
@@ -108,7 +108,7 @@ const SobrePage = () => {
                   className="bg-azul/40 p-6 rounded-lg backdrop-blur-sm"
                 >
                   <div className="bg-verde/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <MapPin className="h-7 w-7 text-verde" />
+                    <HeartHandshake className="h-7 w-7 text-verde" />
                   </div>
                   <h3 className="text-xl font-semibold mb-2 text-verde">Facilitar</h3>
                   <p className="text-cinza">Simplificar o processo de denúncia e acompanhamento de problemas urbanos.</p>
@@ -122,7 +122,7 @@ const SobrePage = () => {
                   className="bg-azul/40 p-6 rounded-lg backdrop-blur-sm"
                 >
                   <div className="bg-verde/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <MapPin className="h-7 w-7 text-verde" />
+                    <Zap className="h-7 w-7 text-verde" />
                   </div>
                   <h3 className="text-xl font-semibold mb-2 text-verde">Transformar</h3>
                   <p className="text-cinza">Impactar positivamente a qualidade de vida nas cidades através da tecnologia.</p>


### PR DESCRIPTION
### 📌 [Ícones] Tornar os ícones da página "Sobre" semanticamente relevantes (5 pontos)

### 🧩 Descrição  
Substituir os ícones genéricos da seção “Sobre” por ícones que representem de forma mais clara e coerente os conteúdos de **propósito, missão e acessibilidade**.

### 🎯 Objetivo  
- Melhorar a **relação entre conteúdo visual e texto**.  
- Aplicar a heurística de **compatibilidade com o mundo real**.  
- Tornar a comunicação mais clara e empática.

### 📊 Pontuação: 5 pontos

### 🌱 Branch: `fix/icons-sobre-coerencia`
