### PR TITLE
[13 pontos] Incluir tooltip com critérios de pontuação na página de perfil

### DIFF
--- a/frontend/src/components/faq/FAQSection.jsx
+++ b/frontend/src/components/faq/FAQSection.jsx
@@ -12,27 +12,27 @@ import { motion } from "framer-motion";
 import { Separator } from "@/components/ui/separator";
 
 const FAQSection = () => {
-  const [activeId, setActiveId] = useState(null);
+  const [activeId, setActiveId] = useState(null)
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
+            setActiveId(entry.target.id)
           }
-        });
+        })
       },
       { threshold: 0.5 }
-    );
+    )
 
     faqCategories.forEach((category) => {
-      const el = document.getElementById(category.id);
-      if (el) observer.observe(el);
-    });
+      const el = document.getElementById(category.id)
+      if (el) observer.observe(el)
+    })
 
-    return () => observer.disconnect();
-  }, []);
+    return () => observer.disconnect()
+  }, [])
 
   return (
     <motion.div
@@ -45,7 +45,7 @@ const FAQSection = () => {
       <div className="md:w-3/4 space-y-10">
         <Card className="border-none shadow-lg">
           <CardHeader className="bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-700 rounded-t-lg border-b border-gray-100 dark:border-gray-700">
-            <CardTitle className="text-xl md:text-2xl text-azul">
+            <CardTitle className="text-xl md:text-2xl text-azul font-bold">
               Dúvidas sobre o Cidade Integra
             </CardTitle>
             <CardDescription className="text-base">
@@ -78,7 +78,7 @@ const FAQSection = () => {
         </Card>
       </div>
     </motion.div>
-  );
-};
+  )
+}
 
-export default FAQSection;
+export default FAQSection

--- a/frontend/src/components/perfil/EstatisticasCard.jsx
+++ b/frontend/src/components/perfil/EstatisticasCard.jsx
@@ -21,7 +21,7 @@ const EstatisticasCard = ({ totalDenuncias, porcentagemResolvidas }) => {
                     <TooltipTrigger asChild>
                       <Info className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" aria-label="Clique para saber como funciona os critérios de pontuação"/>
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-xs bg-verde text-white">
+                    <TooltipContent side="top" className="max-w-xs bg-azul text-white">
                       <div className="space-y-2 text-sm">
                         <p className="font-medium">Como funciona a pontuação?</p>
                         <ul className="space-y-1 text-xs">


### PR DESCRIPTION
### 📌 [Ajuda] Incluir tooltip com critérios de pontuação na página de perfil (13 pontos)

### 🧩 Descrição  
Adicionar um tooltip ou popup explicativo ao lado da pontuação do usuário, explicando **como funciona o sistema de ranking e score** da plataforma.

### 🎯 Objetivo  
- Tornar o sistema mais compreensível e transparente.  
- Aplicar a heurística de **ajuda e documentação**.  
- Melhorar a motivação e engajamento do usuário.

### 📊 Pontuação: 13 pontos

### 🌱 Branch: `feature/tooltip-criterios-pontuacao`
