### PR TITLE
feat: botão voltar ao topo

### DIFF
--- a/frontend/src/pages/SobrePage.jsx
+++ b/frontend/src/pages/SobrePage.jsx
@@ -2,13 +2,32 @@ import StudentCard from "@/components/sobre/StudentCard";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import { students } from "@/data/equipe";
-import { motion } from "framer-motion";
 import { MapPin } from "lucide-react";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
+import { useState, useEffect } from "react";
+import { Link, HeartHandshake, Zap, ArrowUp } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 
 const SobrePage = () => {
 
+  const [showScrollTop, setShowScrollTop] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 300);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -161,6 +180,28 @@ const SobrePage = () => {
         </section>
       </main>
       <Footer />
+      
+      {/* botão de rolar para cima */}
+      <AnimatePresence>
+        {showScrollTop && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8}}
+            className="fixed bottom-6 right-6 z-50"
+          >
+            <Button
+              onClick={scrollToTop}
+              size="icon"
+              className="bg-verde hover:bg-verde-escuro shadow-lg rounded-full h-12 w-12"
+              aria-label="Voltar ao topo"
+            >
+              <ArrowUp className="h-5 w-5" />
+            </Button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
     </div>
   );
 };


### PR DESCRIPTION
### 📌 [UX] Implementar botão de “Voltar ao topo” em páginas longas (21 pontos)

### 🧩 Descrição  
Em páginas extensas como FAQ e histórico de denúncias, o usuário não tem atalho visível para voltar ao topo. Esta melhoria adiciona um botão flutuante com **scrollTo({ top: 0 })** após rolagem de 400px.

### 🎯 Objetivo  
- Agilizar a navegação em conteúdos longos.  
- Aplicar a heurística de **eficiência e flexibilidade de uso**.  
- Reduzir esforço de rolagem manual.

### 📊 Pontuação: 21 pontos

### 🌱 Branch: `feature/botao-voltar-topo`
