### PR TITLE
[1 ponto] Correção de ícones duplicados na navbar

### DIFF
--- a/frontend/src/components/layout/DesktopMenu.jsx
+++ b/frontend/src/components/layout/DesktopMenu.jsx
@@ -9,14 +9,7 @@ import {
   LogOut,
   Plus,
   BookOpen,
-  Users,
-  Users2,
-  Users2Icon,
-  Globe,
-  Globe2,
-  GlobeLock,
   Building2,
-  Building,
 } from "lucide-react"
 
 

--- a/frontend/src/components/layout/DesktopMenu.jsx
+++ b/frontend/src/components/layout/DesktopMenu.jsx
@@ -9,6 +9,14 @@ import {
   LogOut,
   Plus,
   BookOpen,
+  Users,
+  Users2,
+  Users2Icon,
+  Globe,
+  Globe2,
+  GlobeLock,
+  Building2,
+  Building,
 } from "lucide-react"
 
 
@@ -77,7 +85,7 @@ const DesktopMenu = ({ user, onLogout, isLoggingOut }) => {
         tabIndex={0}
 
       >
-        <User size={18} aria-hidden="true" />
+        <Building2 size={18} aria-hidden="true" />
         <span>Sobre</span>
       </Link>
 

--- a/frontend/src/components/layout/MobileMenu.jsx
+++ b/frontend/src/components/layout/MobileMenu.jsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   Plus,
   BookOpen,
+  Building2,
 } from "lucide-react"
 
 const MobileMenu = ({ user, onClickItem, onLogout, isLoggingOut }) => {
@@ -69,7 +70,7 @@ const MobileMenu = ({ user, onClickItem, onLogout, isLoggingOut }) => {
         aria-current={isActiveRoute("/sobre") ? "page" : undefined}
         tabIndex={0}
       >
-        <User size={18} aria-hidden="true" />
+        <Building2 size={18} aria-hidden="true" />
         <span>Sobre</span>
       </Link>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cidade-integra-frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### Nome da issue: [UI 1 ponto] Correção de ícones duplicados na navbar

### 🧩 Descrição
Foi detectada a **duplicação de ícones** no menu de navegação superior para "perfil" e "sobre".

Essa melhoria visa **remover redundâncias visuais**, limpando a navegação e melhorando a experiência do usuário.

### 🎯 Objetivo
- Melhorar organização visual da navbar.
- Evitar confusão visual.

### 📊 Pontuação: 1 ponto

### 🌱 Branch: `fix/navbar-icons`


----

### 📸Prints de Evidencia

**Menu de Navegação com o ícone de "Sobre" alterado (sem login) - Versão Desktop:**
<img width="1033" height="676" alt="image" src="https://github.com/user-attachments/assets/4fd0819f-5ca9-46b7-a15f-fd33b1b03031" />

**Menu de Navegação com o ícone de "Sobre" alterado (logado) - Versão Desktop:**
<img width="1055" height="669" alt="image" src="https://github.com/user-attachments/assets/debb533b-bef0-4bf3-8eef-ba0bacad0e5a" />

**Menu de Navegação com o ícone de "Sobre" alterado (sem login) - Versão Mobile:**
<img width="645" height="902" alt="image" src="https://github.com/user-attachments/assets/e391f0e0-3ffb-4d9e-8416-f5e892fcfc9c" />

**Menu de Navegação com o ícone de "Sobre" alterado (logado) - Versão Mobile:**
<img width="653" height="900" alt="image" src="https://github.com/user-attachments/assets/a53f7196-6737-417e-8ec2-25d078a17f62" />
