### PR TITLE
[5 pontos] Adicionar variedade de gráficos nas estatísticas

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
         "react-router": "^7.4.0",
         "react-router-dom": "^6.26.2",
         "react-select": "^5.10.1",
-        "recharts": "^2.12.7",
+        "recharts": "^2.15.4",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -8421,9 +8421,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
-      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "react-router": "^7.4.0",
     "react-router-dom": "^6.26.2",
     "react-select": "^5.10.1",
-    "recharts": "^2.12.7",
+    "recharts": "^2.15.4",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/components/admin/AdminHeader.jsx
+++ b/frontend/src/components/admin/AdminHeader.jsx
@@ -1,9 +1,19 @@
-import { Shield } from "lucide-react"
+import { Shield, ArrowLeft } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const AdminHeader = () => {
   return (
     <div className="bg-azul text-white py-12">
       <div className="container mx-auto px-4">
+        <div className="flex gap-2 mb-4">
+          <Link
+            to="/admin"
+            className="flex items-center text-cinza hover:text-white mb-4 w-fit"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Voltar para Administração</span>
+          </Link>
+        </div>
         <div className="flex items-center gap-2">
           <Shield className="h-6 w-6 text-verde" />
           <h1 className="text-3xl font-bold">Painel de Administração</h1>
@@ -13,7 +23,7 @@ const AdminHeader = () => {
         </p>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default AdminHeader
+export default AdminHeader;

--- a/frontend/src/components/admin/denuncias/DenunciasStats.jsx
+++ b/frontend/src/components/admin/denuncias/DenunciasStats.jsx
@@ -1,67 +1,160 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { PieChart, Pie, LineChart, Line, XAxis, YAxis, ResponsiveContainer, Cell } from "recharts";
+import { useMemo } from "react";
+
+const STATUS = [
+  { key: "pending", label: "Pendentes", color: "hsl(var(--chart-2))", bar: "bg-yellow-500" },
+  { key: "review", label: "Em Análise", color: "hsl(var(--chart-3))", bar: "bg-blue-500" },
+  { key: "resolved", label: "Resolvidas", color: "hsl(var(--chart-4))", bar: "bg-verde" },
+  { key: "rejected", label: "Rejeitadas", color: "hsl(var(--chart-5))", bar: "bg-vermelho" },
+];
 
 const DenunciasStats = ({ denuncias }) => {
-    
-  const estatisticas = {
-    total: denuncias.length,
-    pendentes: denuncias.filter(d => d.status === "pending").length,
-    emAnalise: denuncias.filter(d => d.status === "review").length,
-    resolvidas: denuncias.filter(d => d.status === "resolved").length,
-    rejeitadas: denuncias.filter(d => d.status === "rejected").length,
-  }
+  const estatisticas = useMemo(() => {
+    const stats = { total: denuncias.length };
+    STATUS.forEach(s => {
+      stats[s.key] = denuncias.filter(d => d.status === s.key).length;
+    });
+    return stats;
+  }, [denuncias]);
+
+  const pieData = STATUS.map(s => ({
+    name: s.label,
+    value: estatisticas[s.key],
+    fill: s.color,
+  }));
+
+  const lineData = useMemo(() => {
+    const denunciasPorMes = denuncias.reduce((acc, denuncia) => {
+      let date;
+      if (denuncia.createdAt?.toDate) {
+        // Firebase Timestamp
+        date = denuncia.createdAt.toDate();
+      } else if (typeof denuncia.createdAt === "string" || typeof denuncia.createdAt === "number") {
+        date = new Date(denuncia.createdAt);
+      } else {
+        return acc; // pula se não conseguir converter
+      }
+      if (isNaN(date)) return acc; // pula datas inválidas
+      const mesAno = `${String(date.getMonth() + 1).padStart(2, '0')}/${date.getFullYear()}`;
+      acc[mesAno] = (acc[mesAno] || 0) + 1;
+      return acc;
+    }, {});
+    return Object.entries(denunciasPorMes)
+      .sort(([a], [b]) => {
+        const [mesA, anoA] = a.split('/');
+        const [mesB, anoB] = b.split('/');
+        return new Date(anoA, mesA - 1) - new Date(anoB, mesB - 1);
+      })
+      .map(([mes, count]) => ({
+        mes,
+        denuncias: count,
+      }));
+  }, [denuncias]);
+
+  const chartConfig = {
+    denuncias: { label: "Denúncias" },
+    ...Object.fromEntries(STATUS.map(s => [s.key, { label: s.label }])),
+  };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Estatísticas de Denúncias</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-6">
-          <div>
-            <h3 className="font-medium mb-2">Distribuição por Status</h3>
-            <div className="space-y-2">
-              <div>
-                <div className="flex justify-between mb-1">
-                  <span className="text-muted-foreground">Pendentes</span>
-                  <span className="font-medium">{estatisticas.pendentes} ({Math.round((estatisticas.pendentes/estatisticas.total)*100)}%)</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2.5">
-                  <div className="bg-yellow-500 h-2.5 rounded-full" style={{ width: `${(estatisticas.pendentes/estatisticas.total)*100}%` }}></div>
-                </div>
-              </div>
-              <div>
-                <div className="flex justify-between mb-1">
-                  <span className="text-muted-foreground">Em análise</span>
-                  <span className="font-medium">{estatisticas.emAnalise} ({Math.round((estatisticas.emAnalise/estatisticas.total)*100)}%)</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2.5">
-                  <div className="bg-blue-500 h-2.5 rounded-full" style={{ width: `${(estatisticas.emAnalise/estatisticas.total)*100}%` }}></div>
-                </div>
-              </div>
-              <div>
-                <div className="flex justify-between mb-1">
-                  <span className="text-muted-foreground">Resolvidas</span>
-                  <span className="font-medium">{estatisticas.resolvidas} ({Math.round((estatisticas.resolvidas/estatisticas.total)*100)}%)</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2.5">
-                  <div className="bg-verde h-2.5 rounded-full" style={{ width: `${(estatisticas.resolvidas/estatisticas.total)*100}%` }}></div>
-                </div>
-              </div>
-              <div>
-                <div className="flex justify-between mb-1">
-                  <span className="text-muted-foreground">Rejeitadas</span>
-                  <span className="font-medium">{estatisticas.rejeitadas} ({Math.round((estatisticas.rejeitadas/estatisticas.total)*100)}%)</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2.5">
-                  <div className="bg-vermelho h-2.5 rounded-full" style={{ width: `${(estatisticas.rejeitadas/estatisticas.total)*100}%` }}></div>
-                </div>
+    <div className="space-y-6">
+      {/* Gráficos */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Gráfico de Pizza */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Distribuição por Status</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer config={chartConfig} className="h-[300px]">
+              <PieChart>
+                <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+                <Pie
+                  data={pieData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  outerRadius={80}
+                  fill="#8884d8"
+                  dataKey="value"
+                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                >
+                  {pieData.map((entry, idx) => (
+                    <Cell key={`cell-${idx}`} fill={entry.fill} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ChartContainer>
+          </CardContent>
+        </Card>
+
+        {/* Gráfico de Linha */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Denúncias por Mês</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer config={chartConfig} className="h-[300px]">
+              <LineChart data={lineData}>
+                <XAxis dataKey="mes" stroke="hsl(var(--muted-foreground))" fontSize={12} />
+                <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Line
+                  type="monotone"
+                  dataKey="denuncias"
+                  stroke="hsl(var(--chart-1))"
+                  strokeWidth={2}
+                  dot={{ fill: "hsl(var(--chart-1))" }}
+                />
+              </LineChart>
+            </ChartContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Estatísticas Detalhadas */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Estatísticas Detalhadas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-6">
+            <div>
+              <h3 className="font-medium mb-2">Distribuição por Status</h3>
+              <div className="space-y-2">
+                {STATUS.map(s => (
+                  <div key={s.key}>
+                    <div className="flex justify-between mb-1">
+                      <span className="text-muted-foreground">{s.label}</span>
+                      <span className="font-medium">
+                        {estatisticas[s.key]} (
+                          {estatisticas.total > 0
+                            ? Math.round((estatisticas[s.key] / estatisticas.total) * 100)
+                            : 0
+                          }%)
+                      </span>
+                    </div>
+                    <div className="w-full bg-muted rounded-full h-2.5">
+                      <div
+                        className={`${s.bar} h-2.5 rounded-full`}
+                        style={{
+                          width: estatisticas.total > 0
+                            ? `${(estatisticas[s.key] / estatisticas.total) * 100}%`
+                            : "0%",
+                        }}
+                      ></div>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
 
-export default DenunciasStats
+export default DenunciasStats;

--- a/frontend/src/components/admin/usuarios/UsersAdminHeader.jsx
+++ b/frontend/src/components/admin/usuarios/UsersAdminHeader.jsx
@@ -1,9 +1,20 @@
-import { UserCog } from "lucide-react"
+import { UserCog } from "lucide-react";
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
 
 const UsersAdminHeader = () => {
   return (
     <div className="bg-azul text-white py-12">
       <div className="container mx-auto px-4">
+        <div className="flex gap-2 mb-4">
+          <Link
+            to="/admin"
+            className="flex items-center text-cinza hover:text-white mb-4 w-fit"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Voltar para Administração</span>
+          </Link>
+        </div>
         <div className="flex items-center gap-2">
           <UserCog className="h-6 w-6 text-verde" />
           <h1 className="text-3xl font-bold">Administração de Usuários</h1>
@@ -13,7 +24,7 @@ const UsersAdminHeader = () => {
         </p>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default UsersAdminHeader
+export default UsersAdminHeader;

--- a/frontend/src/components/admin/usuarios/UsersCharts.jsx
+++ b/frontend/src/components/admin/usuarios/UsersCharts.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+// Cores para os gráficos
+const COLORS = ["#34d399", "#3b82f6", "#f59e42", "#ef4444", "#a78bfa"];
+
+const UsersCharts = ({ users }) => {
+  // Exemplo: Distribuição por status
+  const statusCount = users.reduce((acc, user) => {
+    acc[user.status] = (acc[user.status] || 0) + 1;
+    return acc;
+  }, {});
+
+  const statusData = Object.entries(statusCount).map(([status, count]) => ({
+    name: status.charAt(0).toUpperCase() + status.slice(1),
+    value: count,
+  }));
+
+  // Exemplo: Distribuição por função (role)
+  const roleCount = users.reduce((acc, user) => {
+    acc[user.role] = (acc[user.role] || 0) + 1;
+    return acc;
+  }, {});
+
+  const roleData = Object.entries(roleCount).map(([role, count]) => ({
+    name: role.charAt(0).toUpperCase() + role.slice(1),
+    value: count,
+  }));
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+      {/* Gráfico de Pizza - Status */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4 text-gray-700">
+          Usuários por Status
+        </h2>
+        <ResponsiveContainer width="100%" height={250}>
+          <PieChart>
+            <Pie
+              data={statusData}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              outerRadius={80}
+              label
+            >
+              {statusData.map((entry, index) => (
+                <Cell
+                  key={`cell-status-${index}`}
+                  fill={COLORS[index % COLORS.length]}
+                />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Gráfico de Barras - Função */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4 text-gray-700">
+          Usuários por Função
+        </h2>
+        <ResponsiveContainer width="100%" height={250}>
+          <BarChart data={roleData}>
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="value" fill="#3b82f6" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default UsersCharts;

--- a/frontend/src/components/perfil/PerfilHeader.jsx
+++ b/frontend/src/components/perfil/PerfilHeader.jsx
@@ -1,8 +1,22 @@
 import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "flowbite-react";
 
 const PerfilHeader = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="bg-azul text-white py-12">
+      <div className="container mx-auto px-4">
+        <div
+          onClick={() => navigate(-1)}
+          className="flex items-center text-cinza hover:text-white mb-4 w-fit cursor-pointer"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span>Voltar para página anterior</span>
+        </div>
+      </div>
       <div className="container mx-auto px-4">
         <h1 className="text-3xl font-bold mb-4">Meu Perfil</h1>
         <p className="text-lg text-cinza">

--- a/frontend/src/components/ui/chart.jsx
+++ b/frontend/src/components/ui/chart.jsx
@@ -1,0 +1,308 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = {
+  light: "",
+  dark: ".dark"
+}
+
+const ChartContext = React.createContext(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}>
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({
+  id,
+  config
+}) => {
+  const colorConfig = Object.entries(config).filter(([, config]) => config.theme || config.color)
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+.map(([key, itemConfig]) => {
+const color =
+  itemConfig.theme?.[theme] ||
+  itemConfig.color
+return color ? `  --color-${key}: ${color};` : null
+})
+.join("\n")}
+}
+`)
+          .join("\n"),
+      }} />
+  );
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef((
+  {
+    active,
+    payload,
+    className,
+    indicator = "dot",
+    hideLabel = false,
+    hideIndicator = false,
+    label,
+    labelFormatter,
+    labelClassName,
+    formatter,
+    color,
+    nameKey,
+    labelKey,
+  },
+  ref
+) => {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label]?.label || label
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      );
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}>
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+          const indicatorColor = color || item.payload.fill || item.color
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                indicator === "dot" && "items-center"
+              )}>
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn("shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]", {
+                          "h-2.5 w-2.5": indicator === "dot",
+                          "w-1": indicator === "line",
+                          "w-0 border-[1.5px] border-dashed bg-transparent":
+                            indicator === "dashed",
+                          "my-0.5": nestLabel && indicator === "dashed",
+                        })}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor
+                          }
+                        } />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center"
+                    )}>
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="font-mono font-medium tabular-nums text-foreground">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+})
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef((
+  { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+  ref
+) => {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}>
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`
+        const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+            )}>
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }} />
+            )}
+            {itemConfig?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+})
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config,
+  payload,
+  key
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey = key
+
+  if (
+    key in payload &&
+    typeof payload[key] === "string"
+  ) {
+    configLabelKey = payload[key]
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key] === "string"
+  ) {
+    configLabelKey = payloadPayload[key]
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/frontend/src/pages/UsersAdminPage.jsx
+++ b/frontend/src/pages/UsersAdminPage.jsx
@@ -6,15 +6,16 @@ import UsersAdminHeader from "@/components/admin/usuarios/UsersAdminHeader";
 import UsersSearch from "@/components/admin/usuarios/UsersSearch";
 import UsersStats from "@/components/admin/usuarios/UsersStats";
 import UsersTable from "@/components/admin/usuarios/UsersTable";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import UsersCharts from "@/components/admin/usuarios/UsersCharts";
 
-import {useAllUsers} from "@/hooks/useAllUsers";
+import { useAllUsers } from "@/hooks/useAllUsers";
 
 const UsersAdminPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [filter, setFilter] = useState("todos");
   const { toast } = useToast();
   const { users, loading, error } = useAllUsers();
-
 
   const atualizarStatus = async (id, novoStatus) => {
     try {
@@ -67,25 +68,33 @@ const UsersAdminPage = () => {
         <UsersAdminHeader />
 
         <div className="container mx-auto px-4 py-8">
+
+          <UsersStats users={users} />
+
           {loading ? (
             <p>Carregando usuários...</p>
           ) : error ? (
             <p className="text-red-500">Erro ao carregar usuários.</p>
           ) : (
-            <>
-              <UsersStats users={users} />
+            <Tabs defaultValue="usuarios" className="w-full">
+              <TabsList className="grid w-full max-w-md grid-cols-2 mb-6">
+                <TabsTrigger value="usuarios">Usuários</TabsTrigger>
+                <TabsTrigger value="estatisticas">Estatísticas</TabsTrigger>
+              </TabsList>
+              <TabsContent value="usuarios">
+                <UsersSearch
+                  searchTerm={searchTerm}
+                  setSearchTerm={setSearchTerm}
+                  filter={filter}
+                  setFilter={setFilter}
+                />
 
-              <UsersSearch
-                searchTerm={searchTerm}
-                setSearchTerm={setSearchTerm}
-                filter={filter}
-                setFilter={setFilter}
-              />
-
-              <UsersTable
-                users={filteredUsers}
-              />
-            </>
+                <UsersTable users={filteredUsers} />
+              </TabsContent>
+              <TabsContent value="estatisticas">
+                <UsersCharts users={users} />
+              </TabsContent>
+            </Tabs>
           )}
         </div>
       </main>


### PR DESCRIPTION
### Nome da issue: [Dashboard 5 pontos] Adicionar variedade de gráficos nas estatísticas

### 🧩 Descrição
A área de estatísticas para administradores está limitada. Serão incluídos **gráficos adicionais e mais variados** (ex: pizza, linha, barra) sobre denúncias e usuários.

### 🎯 Objetivo
- Fornecer insights mais ricos para os administradores.
- Melhorar tomada de decisão baseada em dados.

### 📊 Pontuação: 5 pontos

### 🌱 Branch: `feature/dashboard-graficos`
